### PR TITLE
ci: allow badge push on workflow_dispatch

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -55,7 +55,7 @@ jobs:
           publish_results: false
 
       - name: Generate scorecard badge
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
           SCORE=$(python3 -c "import json; print(json.load(open('results.json'))['score'])")
           if python3 -c "exit(0 if float('$SCORE') >= 7.0 else 1)"; then COLOR="brightgreen";
@@ -66,7 +66,7 @@ jobs:
           curl -s "https://img.shields.io/badge/openssf_scorecard-${SCORE}-${COLOR}" > .github/badges/scorecard.svg
 
       - name: Commit scorecard badge
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,7 +145,7 @@ jobs:
 
   quality-gate-bump:
     name: Bump quality gate
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
## Summary
- Quality gate bump job (`tests.yml`) now runs on `workflow_dispatch` in addition to `push`
- Scorecard badge generate + commit steps (`scorecard.yml`) now run on `workflow_dispatch` in addition to `push`

Allows manual triggering to test badge push after disabling `enforce_admins`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)