### PR TITLE
fix: use BADGE_PUSH_TOKEN for badge push to main

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -31,12 +31,12 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          token: ${{ secrets.SCORECARD_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BADGE_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Run Scorecard
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
         with:
-          repo_token: ${{ secrets.SCORECARD_TOKEN || secrets.GITHUB_TOKEN }}
+          repo_token: ${{ secrets.BADGE_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
           results_file: results.sarif
           results_format: sarif
           publish_results: false
@@ -49,7 +49,7 @@ jobs:
       - name: Run Scorecard (JSON for badge)
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
         with:
-          repo_token: ${{ secrets.SCORECARD_TOKEN || secrets.GITHUB_TOKEN }}
+          repo_token: ${{ secrets.BADGE_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
           results_file: results.json
           results_format: json
           publish_results: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -159,7 +159,7 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BADGE_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Download test metrics
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3  # v8


### PR DESCRIPTION
## Summary
- Use `BADGE_PUSH_TOKEN` (fine-grained PAT) in checkout steps for badge push jobs
- Updates both `tests.yml` (quality gate bump) and `scorecard.yml` (scorecard badge)
- Falls back to `GITHUB_TOKEN` if secret is not set

Fixes the badge push being blocked by branch protection — GITHUB_TOKEN can't push to protected branches even with `enforce_admins: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)