### PR TITLE
ci: add PyPI release workflow (OIDC trusted publisher)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,11 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: "3.12"
+
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098  # v7.3.1
         with:
@@ -61,7 +66,7 @@ jobs:
 
   attach-assets:
     name: Attach assets to release
-    needs: build
+    needs: publish
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -81,6 +86,7 @@ jobs:
       - name: Attach to GitHub Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
         with:
+          tag_name: ${{ github.event.release.tag_name }}
           files: |
             dist/*.tar.gz
             dist/*.whl


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` — triggered on GitHub Release publish
- 3-job pipeline: **build** (uv build) → **publish** (OIDC via pypa/gh-action-pypi-publish) → **attach-assets** (sdist + wheel on the Release)
- No credentials stored — uses PyPI trusted publisher + `id-token: write`

## Security

- Top-level `permissions: {}` (deny all), job-scoped minimal permissions
- All actions SHA-pinned with version comments
- `step-security/harden-runner` on every job
- `timeout-minutes` on every job

## Test plan

- [x] YAML validates (`yaml.safe_load`)
- [x] `uv build` produces expected `grippy_code_review-0.2.0.tar.gz` + `.whl`
- [ ] Dry-run: create draft release → verify workflow triggers → cancel before publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)