### PR TITLE
fix: use dedicated SCORECARD_TOKEN for branch protection read access

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run Scorecard
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
         with:
-          repo_token: ${{ secrets.BADGE_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
+          repo_token: ${{ secrets.SCORECARD_TOKEN || secrets.GITHUB_TOKEN }}
           results_file: results.sarif
           results_format: sarif
           publish_results: false
@@ -49,7 +49,7 @@ jobs:
       - name: Run Scorecard (JSON for badge)
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
         with:
-          repo_token: ${{ secrets.BADGE_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
+          repo_token: ${{ secrets.SCORECARD_TOKEN || secrets.GITHUB_TOKEN }}
           results_file: results.json
           results_format: json
           publish_results: false


### PR DESCRIPTION
## Summary

- Switch scorecard action `repo_token` from `BADGE_PUSH_TOKEN` to `SCORECARD_TOKEN` (both SARIF and JSON runs)
- The `SCORECARD_TOKEN` is a fine-grained PAT with `Administration:Read` permission, which scorecard needs to evaluate branch protection rules
- The previous token lacked this, causing the Branch-Protection check to error with score -1
- Checkout/push steps still use `BADGE_PUSH_TOKEN` since they need `contents:write`

## Test plan

- [ ] Verify `SCORECARD_TOKEN` secret exists in repo settings
- [ ] Merge and confirm next scorecard run evaluates Branch-Protection (score >= 0 instead of -1)
- [ ] Verify badge push still works via `BADGE_PUSH_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)