### PR TITLE
feat: add SLSA Level 3 build provenance + unified badge header

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -25,9 +25,11 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: grippy-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 > Open-source AI code review agent. Your model, your infrastructure, your rules.
 
 [![Tests](https://github.com/Project-Navi/grippy-code-review/actions/workflows/tests.yml/badge.svg)](https://github.com/Project-Navi/grippy-code-review/actions/workflows/tests.yml)
-[![CodeQL](https://github.com/Project-Navi/grippy-code-review/actions/workflows/codeql.yml/badge.svg)](https://github.com/Project-Navi/grippy-code-review/actions/workflows/codeql.yml)
 [![codecov](https://codecov.io/gh/Project-Navi/grippy-code-review/graph/badge.svg)](https://codecov.io/gh/Project-Navi/grippy-code-review)
+[![CodeQL](https://github.com/Project-Navi/grippy-code-review/actions/workflows/codeql.yml/badge.svg)](https://github.com/Project-Navi/grippy-code-review/actions/workflows/codeql.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Project-Navi/grippy-code-review/badge)](https://scorecard.dev/viewer/?uri=github.com/Project-Navi/grippy-code-review)
 [![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
 [![PyPI](https://img.shields.io/badge/PyPI-coming%20soon-lightgrey)](https://pypi.org/project/grippy-code-review/)


### PR DESCRIPTION
## Summary

- Add `_build-reusable.yml` — reusable workflow with `attest-build-provenance` for SLSA L3 non-falsifiable provenance
- Refactor `release.yml` to call the reusable workflow (build isolation boundary)
- Standardize README badge header: Tests | CodeQL | Coverage | Scorecard | SLSA 3 | PyPI | License | Python | Ruff
- Switch coverage badge from self-hosted SVG to Codecov hosted
- Switch scorecard badge from self-hosted SVG to api.scorecard.dev dynamic
- Add CodeQL, SLSA 3, Ruff, and PyPI (coming soon) badges

## Test plan

- [ ] Verify reusable workflow syntax passes Actions validation
- [ ] Cut a test release to confirm provenance attestation is generated
- [ ] Verify `gh attestation verify` works on release artifacts
- [ ] Confirm badges render correctly in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)