### PR TITLE
fix: tune Grippy review accuracy — stale threads, confidence, re-review

### DIFF
--- a/src/grippy/agent.py
+++ b/src/grippy/agent.py
@@ -209,6 +209,7 @@ def format_pr_context(
     governance_rules: str = "",
     learnings: str = "",
     rule_findings: str = "",
+    changed_since_last_review: str = "",
 ) -> str:
     """Format PR context as the user message, matching pr-review.md input format."""
     sections = [
@@ -239,6 +240,11 @@ def format_pr_context(
         f"Deletions: {deletions}\n"
         f"</pr_metadata>"
     )
+
+    if changed_since_last_review:
+        sections.append(
+            f"<review_context>\n{_escape_xml(changed_since_last_review)}\n</review_context>"
+        )
 
     sections.append(f"<diff>\n{_escape_xml(diff)}\n</diff>")
 

--- a/src/grippy/github_review.py
+++ b/src/grippy/github_review.py
@@ -354,9 +354,9 @@ def post_review(
 
     GitHub owns finding lifecycle:
     1. Fetch existing grippy comments from this PR
-    2. Compare new findings against existing — skip matches
+    2. Compare new findings against existing — skip matches (marker dedup)
     3. Post only genuinely new findings as inline comments
-    4. Resolve threads for findings no longer present
+    4. Query GitHub GraphQL for thread states — resolve only outdated threads
     5. Post/update summary with delta counts
 
     Args:
@@ -384,9 +384,18 @@ def post_review(
         if key not in existing:
             new_findings.append(finding)
 
-    # 3. Identify resolved: existing comments not in current findings
+    # 3. Identify stale: use GitHub's isOutdated tracking instead of marker-key diff.
+    #    A thread is stale if GitHub marked it outdated (line moved/removed) AND
+    #    its marker key is no longer in the current findings.
     current_keys = {(f.file, f.category.value, f.line_start) for f in findings}
-    resolved_comments = [comment for key, comment in existing.items() if key not in current_keys]
+    absent_comments = [comment for key, comment in existing.items() if key not in current_keys]
+    resolved_comments: list[Any] = []
+    if absent_comments:
+        thread_states = fetch_thread_states([c.node_id for c in absent_comments])
+        for comment in absent_comments:
+            state = thread_states.get(comment.node_id, {})
+            if state.get("isOutdated", False) and not state.get("isResolved", False):
+                resolved_comments.append(comment)
 
     # Detect fork PR — GITHUB_TOKEN is read-only for forks
     is_fork = (
@@ -470,6 +479,65 @@ def post_review(
 
 
 # --- Thread resolution ---
+
+
+def fetch_thread_states(thread_ids: list[str]) -> dict[str, dict[str, bool]]:
+    """Fetch isOutdated and isResolved state for review threads via GraphQL.
+
+    Uses ``gh api graphql`` subprocess with the ``nodes`` query to batch-fetch
+    thread metadata. GitHub marks threads as ``isOutdated`` when the underlying
+    diff line has moved or been removed — this is more reliable than comparing
+    marker keys across commits.
+
+    Args:
+        thread_ids: List of GitHub review thread node IDs (PRRT_...).
+
+    Returns:
+        Dict mapping thread_id to ``{"isOutdated": bool, "isResolved": bool}``.
+        Missing/failed IDs are omitted from the result.
+    """
+    import json
+
+    if not thread_ids:
+        return {}
+
+    _nodes_query = (
+        "query FetchThreadStates($ids: [ID!]!) { "
+        "nodes(ids: $ids) { "
+        "... on PullRequestReviewThread { id isOutdated isResolved } } }"
+    )
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "api",
+                "graphql",
+                "-f",
+                f"query={_nodes_query}",
+                "-f",
+                f"ids={json.dumps(thread_ids)}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        if result.returncode != 0:
+            print(f"::warning::Failed to fetch thread states: {result.stderr}")
+            return {}
+
+        data = json.loads(result.stdout)
+        states: dict[str, dict[str, bool]] = {}
+        for node in data.get("data", {}).get("nodes", []):
+            if node and "id" in node:
+                states[node["id"]] = {
+                    "isOutdated": node.get("isOutdated", False),
+                    "isResolved": node.get("isResolved", False),
+                }
+        return states
+    except Exception as exc:
+        print(f"::warning::Exception fetching thread states: {exc}")
+        return {}
 
 
 def resolve_threads(

--- a/src/grippy/prompts_data/confidence-filter.md
+++ b/src/grippy/prompts_data/confidence-filter.md
@@ -23,6 +23,29 @@ Default thresholds:
 
 Log suppressed findings in `meta.confidence_filter_suppressed` count.
 
+### Stage 1b: Confidence Calibration Adjustments
+
+Apply these adjustments BEFORE threshold comparison:
+
+**Category penalty — governance and observability findings:**
+Findings in the `governance` or `observability` categories reflect code quality
+and maintainability, not production failures. Subtract 15 from their raw
+confidence score. A governance finding you're 90% sure about becomes 75% after
+adjustment. This prevents style opinions from competing with concrete
+vulnerabilities for attention.
+
+**Specificity ceiling — findings without concrete breakage evidence:**
+Any finding where the described issue is about what SHOULD exist but doesn't
+(missing error handling, missing logging, missing permissions pattern, missing
+tests) rather than what WILL break in production (SQL injection, auth bypass,
+data corruption) is capped at 80 confidence regardless of how certain you are
+about the pattern. If you cannot describe a specific, reproducible failure mode
+triggered by the code as written, the ceiling applies.
+
+These adjustments stack: a governance finding about a missing pattern starts
+at raw confidence, subtracts 15, then caps at 80 — so a 95% raw governance
+"should exist" finding becomes min(95 - 15, 80) = 80.
+
 ### Stage 2: Deduplication
 
 For findings that reference the same file and overlapping line ranges:

--- a/src/grippy/prompts_data/scoring-rubric.md
+++ b/src/grippy/prompts_data/scoring-rubric.md
@@ -52,6 +52,10 @@ Every finding gets a confidence score from 0-100. This is YOUR confidence that t
 
 **The confidence filter (tools/confidence-filter.md) suppresses findings below the configured threshold. Default: 75.**
 
+**Calibration adjustments (applied before threshold):**
+- **Governance/observability category penalty:** Subtract 15 from confidence for findings in the `governance` or `observability` categories. These reflect code quality, not production failures.
+- **Specificity ceiling:** Findings about what SHOULD exist but doesn't (missing error handling, missing permissions, missing tests) cap at 80 confidence. If you cannot describe a specific, reproducible failure mode triggered by the code as written, cap at 80.
+
 ## Overall Audit Score Calculation
 
 Start at **100 points**. Deduct per finding based on severity.

--- a/src/grippy/review.py
+++ b/src/grippy/review.py
@@ -89,6 +89,7 @@ def load_pr_event(event_path: Path) -> dict[str, Any]:
         "head_sha": pr["head"].get("sha", ""),
         "base_ref": pr["base"]["ref"],
         "description": pr.get("body") or "",
+        "before_sha": data.get("before", ""),
     }
 
 
@@ -138,6 +139,38 @@ def fetch_pr_diff(token: str, repo: str, pr_number: int) -> str:
     response = requests.get(url, headers=headers, timeout=60)
     response.raise_for_status()
     return response.text
+
+
+def fetch_changed_since(token: str, repo: str, before: str, after: str) -> list[str]:
+    """Fetch file paths changed between two commits via GitHub compare API.
+
+    Used to annotate re-reviews with which files changed since the last review.
+    Non-fatal — returns empty list on any error.
+
+    Args:
+        token: GitHub API token.
+        repo: Repository full name (owner/repo).
+        before: Previous HEAD SHA (from synchronize event ``before`` field).
+        after: Current HEAD SHA.
+
+    Returns:
+        List of file paths that changed between the two commits.
+    """
+    import requests
+
+    url = f"https://api.github.com/repos/{repo}/compare/{before}...{after}"
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github.v3+json",
+    }
+    try:
+        response = requests.get(url, headers=headers, timeout=30)
+        response.raise_for_status()
+        data = response.json()
+        return [f["filename"] for f in data.get("files", [])]
+    except Exception as exc:
+        print(f"::warning::Failed to fetch changed files since last review: {exc}")
+        return []
 
 
 def post_comment(token: str, repo: str, pr_number: int, body: str) -> None:
@@ -445,6 +478,22 @@ def main(*, profile: str | None = None) -> None:
         except Exception as exc:
             print(f"::warning::Graph context query failed (non-fatal): {exc}")
 
+    # 3e. Detect re-review: annotate files changed since last review (non-fatal)
+    changed_since_text = ""
+    before_sha = pr_event.get("before_sha", "")
+    head_sha = pr_event.get("head_sha", "")
+    if before_sha and head_sha and before_sha != head_sha:
+        changed_files = fetch_changed_since(token, pr_event["repo"], before_sha, head_sha)
+        if changed_files:
+            changed_since_text = (
+                f"This is a RE-REVIEW. The following {len(changed_files)} file(s) changed "
+                f"since the last review (commit {before_sha[:7]}):\n"
+                + "\n".join(f"  - {f}" for f in changed_files)
+                + "\n\nPrioritize reviewing changes in these files. "
+                "The rest of the diff was already reviewed in a prior run."
+            )
+            print(f"  Re-review: {len(changed_files)} files changed since {before_sha[:7]}")
+
     # 4. Format context
     description = pr_event["description"]
     if graph_context_text:
@@ -457,6 +506,7 @@ def main(*, profile: str | None = None) -> None:
         description=description,
         diff=diff,
         rule_findings=rule_findings_text,
+        changed_since_last_review=changed_since_text,
     )
 
     # 5. Run review with retry + validation (replaces agent.run + parse_review_response)

--- a/tests/test_grippy_agent.py
+++ b/tests/test_grippy_agent.py
@@ -206,6 +206,34 @@ class TestFormatPrContext:
         assert "<governance_rules>" not in result
         assert "<file_context>" not in result
         assert "<learnings>" not in result
+        assert "<review_context>" not in result
+
+    def test_changed_since_last_review_included(self) -> None:
+        """Re-review annotation appears in review_context section before diff."""
+        result = format_pr_context(
+            title="test",
+            author="dev",
+            branch="a -> b",
+            diff=SAMPLE_DIFF,
+            changed_since_last_review="This is a RE-REVIEW. Files: src/app.py",
+        )
+        assert "<review_context>" in result
+        assert "RE-REVIEW" in result
+        assert "</review_context>" in result
+        # review_context appears before diff
+        ctx_pos = result.index("<review_context>")
+        diff_pos = result.index("<diff>")
+        assert ctx_pos < diff_pos
+
+    def test_changed_since_last_review_omitted_when_empty(self) -> None:
+        result = format_pr_context(
+            title="test",
+            author="dev",
+            branch="a -> b",
+            diff=SAMPLE_DIFF,
+            changed_since_last_review="",
+        )
+        assert "<review_context>" not in result
 
     def test_xml_delimiters_escaped_in_pr_metadata(self) -> None:
         """XML delimiters in PR metadata fields are escaped to prevent prompt injection."""

--- a/tests/test_grippy_github_review.py
+++ b/tests/test_grippy_github_review.py
@@ -550,11 +550,15 @@ class TestPostReview:
         assert mock_pr.create_review.call_args.kwargs["event"] == "APPROVE"
 
     @patch("grippy.github_review.resolve_threads")
+    @patch("grippy.github_review.fetch_thread_states")
     @patch("grippy.github_review.Github")
-    def test_resolves_absent_findings(
-        self, mock_github_cls: MagicMock, mock_resolve: MagicMock
+    def test_resolves_absent_outdated_findings(
+        self,
+        mock_github_cls: MagicMock,
+        mock_fetch_states: MagicMock,
+        mock_resolve: MagicMock,
     ) -> None:
-        """Existing comments not in current findings get their threads resolved."""
+        """Absent findings marked outdated by GitHub get their threads resolved."""
         from grippy.github_review import post_review
 
         mock_pr = MagicMock()
@@ -563,6 +567,9 @@ class TestPostReview:
         mock_pr.head.repo.full_name = "org/repo"
         mock_pr.base.repo.full_name = "org/repo"
         mock_resolve.return_value = 1
+        mock_fetch_states.return_value = {
+            "PRRT_old": {"isOutdated": True, "isResolved": False},
+        }
 
         # Existing comment for a finding that's no longer present
         old_comment = MagicMock()
@@ -570,7 +577,6 @@ class TestPostReview:
         old_comment.node_id = "PRRT_old"
         mock_pr.get_review_comments.return_value = [old_comment]
 
-        # Current findings don't include old.py:logic:5
         post_review(
             token="test-token",
             repo="org/repo",
@@ -585,6 +591,84 @@ class TestPostReview:
         mock_resolve.assert_called_once()
         call_kwargs = mock_resolve.call_args[1]
         assert "PRRT_old" in call_kwargs["thread_ids"]
+
+    @patch("grippy.github_review.resolve_threads")
+    @patch("grippy.github_review.fetch_thread_states")
+    @patch("grippy.github_review.Github")
+    def test_skips_absent_but_not_outdated(
+        self,
+        mock_github_cls: MagicMock,
+        mock_fetch_states: MagicMock,
+        mock_resolve: MagicMock,
+    ) -> None:
+        """Absent findings NOT marked outdated by GitHub are not resolved."""
+        from grippy.github_review import post_review
+
+        mock_pr = MagicMock()
+        mock_github_cls.return_value.get_repo.return_value.get_pull.return_value = mock_pr
+        mock_pr.get_issue_comments.return_value = []
+        mock_pr.head.repo.full_name = "org/repo"
+        mock_pr.base.repo.full_name = "org/repo"
+        mock_fetch_states.return_value = {
+            "PRRT_still_valid": {"isOutdated": False, "isResolved": False},
+        }
+
+        old_comment = MagicMock()
+        old_comment.body = "old\n<!-- grippy:old.py:logic:5 -->"
+        old_comment.node_id = "PRRT_still_valid"
+        mock_pr.get_review_comments.return_value = [old_comment]
+
+        post_review(
+            token="test-token",
+            repo="org/repo",
+            pr_number=1,
+            findings=[],
+            head_sha="abc",
+            diff="",
+            score=90,
+            verdict="PASS",
+        )
+
+        mock_resolve.assert_not_called()
+
+    @patch("grippy.github_review.resolve_threads")
+    @patch("grippy.github_review.fetch_thread_states")
+    @patch("grippy.github_review.Github")
+    def test_skips_already_resolved_threads(
+        self,
+        mock_github_cls: MagicMock,
+        mock_fetch_states: MagicMock,
+        mock_resolve: MagicMock,
+    ) -> None:
+        """Threads already resolved by GitHub are not re-resolved."""
+        from grippy.github_review import post_review
+
+        mock_pr = MagicMock()
+        mock_github_cls.return_value.get_repo.return_value.get_pull.return_value = mock_pr
+        mock_pr.get_issue_comments.return_value = []
+        mock_pr.head.repo.full_name = "org/repo"
+        mock_pr.base.repo.full_name = "org/repo"
+        mock_fetch_states.return_value = {
+            "PRRT_done": {"isOutdated": True, "isResolved": True},
+        }
+
+        old_comment = MagicMock()
+        old_comment.body = "old\n<!-- grippy:old.py:logic:5 -->"
+        old_comment.node_id = "PRRT_done"
+        mock_pr.get_review_comments.return_value = [old_comment]
+
+        post_review(
+            token="test-token",
+            repo="org/repo",
+            pr_number=1,
+            findings=[],
+            head_sha="abc",
+            diff="",
+            score=90,
+            verdict="PASS",
+        )
+
+        mock_resolve.assert_not_called()
 
 
 # --- verdict review (APPROVE / REQUEST_CHANGES) ---
@@ -688,6 +772,95 @@ class TestVerdictReview:
         )
 
         mock_pr.create_issue_comment.assert_called_once()
+
+
+# --- fetch_thread_states ---
+
+
+class TestFetchThreadStates:
+    """fetch_thread_states queries GitHub GraphQL for thread metadata."""
+
+    @patch("grippy.github_review.subprocess.run")
+    def test_returns_thread_states(self, mock_run: MagicMock) -> None:
+        import json
+
+        from grippy.github_review import fetch_thread_states
+
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "data": {
+                        "nodes": [
+                            {"id": "PRRT_1", "isOutdated": True, "isResolved": False},
+                            {"id": "PRRT_2", "isOutdated": False, "isResolved": True},
+                        ]
+                    }
+                }
+            ),
+        )
+        result = fetch_thread_states(["PRRT_1", "PRRT_2"])
+        assert result["PRRT_1"]["isOutdated"] is True
+        assert result["PRRT_1"]["isResolved"] is False
+        assert result["PRRT_2"]["isOutdated"] is False
+        assert result["PRRT_2"]["isResolved"] is True
+
+    @patch("grippy.github_review.subprocess.run")
+    def test_empty_ids_no_call(self, mock_run: MagicMock) -> None:
+        from grippy.github_review import fetch_thread_states
+
+        result = fetch_thread_states([])
+        assert result == {}
+        mock_run.assert_not_called()
+
+    @patch("grippy.github_review.subprocess.run")
+    def test_failure_returns_empty(self, mock_run: MagicMock) -> None:
+        from grippy.github_review import fetch_thread_states
+
+        mock_run.return_value = MagicMock(returncode=1, stderr="error")
+        result = fetch_thread_states(["PRRT_1"])
+        assert result == {}
+
+    @patch("grippy.github_review.subprocess.run")
+    def test_null_nodes_skipped(self, mock_run: MagicMock) -> None:
+        """Null nodes (e.g. deleted threads) are skipped gracefully."""
+        import json
+
+        from grippy.github_review import fetch_thread_states
+
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "data": {
+                        "nodes": [
+                            None,
+                            {"id": "PRRT_2", "isOutdated": True, "isResolved": False},
+                        ]
+                    }
+                }
+            ),
+        )
+        result = fetch_thread_states(["PRRT_bad", "PRRT_2"])
+        assert "PRRT_bad" not in result
+        assert result["PRRT_2"]["isOutdated"] is True
+
+    @patch("grippy.github_review.subprocess.run")
+    def test_uses_graphql_variables(self, mock_run: MagicMock) -> None:
+        """Thread IDs are passed as GraphQL variables, not interpolated."""
+        import json
+
+        from grippy.github_review import fetch_thread_states
+
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps({"data": {"nodes": []}}),
+        )
+        fetch_thread_states(["PRRT_1"])
+        cmd = mock_run.call_args[0][0]
+        query_args = [a for a in cmd if a.startswith("query=")]
+        assert "$ids" in query_args[0]
+        assert "PRRT_1" not in query_args[0]
 
 
 # --- resolve_threads ---

--- a/tests/test_grippy_review.py
+++ b/tests/test_grippy_review.py
@@ -180,6 +180,93 @@ class TestLoadPrEvent:
         result = load_pr_event(event_path)
         assert result["description"] == ""
 
+    def test_extracts_before_sha_from_synchronize(self, tmp_path: Path) -> None:
+        """Extracts before SHA from synchronize event for re-review detection."""
+        event = {
+            "action": "synchronize",
+            "before": "abc1234",
+            "after": "def5678",
+            "pull_request": {
+                "number": 10,
+                "title": "feat: stuff",
+                "user": {"login": "dev"},
+                "head": {"ref": "feat", "sha": "def5678"},
+                "base": {"ref": "main"},
+                "body": "",
+            },
+            "repository": {"full_name": "org/repo"},
+        }
+        event_path = tmp_path / "event.json"
+        event_path.write_text(json.dumps(event))
+
+        result = load_pr_event(event_path)
+        assert result["before_sha"] == "abc1234"
+
+    def test_before_sha_empty_on_opened(self, tmp_path: Path) -> None:
+        """before_sha is empty string when event lacks before field (opened)."""
+        event = {
+            "action": "opened",
+            "pull_request": {
+                "number": 1,
+                "title": "feat: new",
+                "user": {"login": "dev"},
+                "head": {"ref": "feat"},
+                "base": {"ref": "main"},
+                "body": "",
+            },
+            "repository": {"full_name": "org/repo"},
+        }
+        event_path = tmp_path / "event.json"
+        event_path.write_text(json.dumps(event))
+
+        result = load_pr_event(event_path)
+        assert result["before_sha"] == ""
+
+
+# --- fetch_changed_since ---
+
+
+class TestFetchChangedSince:
+    """fetch_changed_since uses GitHub compare API to identify re-review delta."""
+
+    @patch("requests.get")
+    def test_returns_changed_filenames(self, mock_get: MagicMock) -> None:
+        from grippy.review import fetch_changed_since
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "files": [
+                {"filename": "src/app.py"},
+                {"filename": "tests/test_app.py"},
+            ]
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        result = fetch_changed_since("token", "org/repo", "abc", "def")
+        assert result == ["src/app.py", "tests/test_app.py"]
+        assert "compare/abc...def" in mock_get.call_args[0][0]
+
+    @patch("requests.get")
+    def test_empty_on_api_failure(self, mock_get: MagicMock) -> None:
+        from grippy.review import fetch_changed_since
+
+        mock_get.side_effect = Exception("API error")
+        result = fetch_changed_since("token", "org/repo", "abc", "def")
+        assert result == []
+
+    @patch("requests.get")
+    def test_empty_on_no_files(self, mock_get: MagicMock) -> None:
+        from grippy.review import fetch_changed_since
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"files": []}
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        result = fetch_changed_since("token", "org/repo", "abc", "def")
+        assert result == []
+
 
 # --- C1: fetch_pr_diff uses raw diff API, not paginated compare ---
 


### PR DESCRIPTION
## Summary
- **Stale thread resolution:** Uses GitHub GraphQL `isOutdated` field instead of marker-key diffing to prevent accumulating resolved findings across re-reviews
- **Confidence calibration:** -15 penalty for governance/observability categories + cap at 80 for "should exist" findings without concrete breakage evidence
- **Re-review annotations:** Detects changed files via GitHub compare API and annotates context so the agent prioritizes new changes over already-reviewed code

## Test plan
- [x] 656 tests passing (447 lines added across 8 files)
- [x] 8 new/updated tests for GraphQL stale thread detection
- [x] 5 new tests for re-review annotation (fetch_changed_since, before_sha, format_pr_context)
- [x] Full adversarial suite (44 attack scenarios) still passing
- [ ] Verify on next real PR review that Grippy doesn't accumulate stale findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)