### PR TITLE
fix: add missing contents:read permission to scorecard analysis job

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
+      contents: read
       security-events: write
       id-token: write
       actions: read


### PR DESCRIPTION
## Summary
- The `analysis` job in the scorecard workflow was missing `contents: read` permission
- Since the top-level `permissions: {}` removes all defaults, `actions/checkout` had no token and failed with `could not read Username for 'https://github.com'`
- The `badge` job already had `contents: write` so it wasn't affected

## Test plan
- [ ] Verify scorecard workflow passes on merge to main
- [ ] Confirm badge job still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)