### PR TITLE
fix: use SCORECARD_TOKEN for quality gate bump checkout

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -167,7 +167,7 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
-          token: ${{ secrets.BADGE_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SCORECARD_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Download test metrics
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3  # v8


### PR DESCRIPTION
## Summary
- The `quality-gate-bump` job in `tests.yml` used `BADGE_PUSH_TOKEN` which is stale/expired
- Swapped to `SCORECARD_TOKEN` which is the active PAT for badge push workflows
- This caused `actions/checkout` to fail with `could not read Username for 'https://github.com'`

## Test plan
- [ ] Verify quality-gate-bump job passes on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)