### PR TITLE
fix: vendor brand CSS and remove private repo fetch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,10 +29,6 @@ jobs:
       - name: Install docs dependencies
         # For library repos, remove --no-install-project so the package is importable
         run: uv sync --frozen --group docs
-      - name: Fetch brand CSS
-        run: |
-          curl -sL https://raw.githubusercontent.com/Project-Navi/brand/main/docs/stylesheets/navi.css \
-            -o docs/stylesheets/navi.css
       - name: Build site
         run: uv run zensical build
       - name: Strip internal docs from build

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,8 +4,6 @@ hide:
   - toc
 ---
 
-<div class="hero-glow" markdown>
-
 # grippy-code-review
 
 **AI-powered PR review agent with security rule engine.**
@@ -14,8 +12,6 @@ Runs with any OpenAI-compatible model as an MCP server or GitHub Actions workflo
 
 [Get Started](getting-started/quickstart.md){ .md-button .md-button--primary }
 [Configuration](how-to/configuration.md){ .md-button }
-
-</div>
 
 ---
 

--- a/docs/stylesheets/navi.css
+++ b/docs/stylesheets/navi.css
@@ -207,28 +207,6 @@ body {
   color: #7eb8a8;
 }
 
-/* --- Hero glow (landing page only) --- */
-.md-content .hero-glow {
-  position: relative;
-}
-
-.md-content .hero-glow::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 150%;
-  height: 400px;
-  background: radial-gradient(
-    ellipse at center top,
-    rgba(126, 184, 168, 0.08) 0%,
-    transparent 70%
-  );
-  pointer-events: none;
-  z-index: -1;
-}
-
 /* --- Primary button — inverted per brand guide --- */
 .md-typeset .md-button--primary {
   background: #e8e4de;


### PR DESCRIPTION
## Summary
- Vendor canonical `navi.css` directly (remove hero-glow styles)
- Remove `Fetch brand CSS` step from `docs.yml` that curls from private `brand` repo
- Remove `hero-glow` div from `index.md` (glow CSS removed, kept only on org index)

## Context
The brand repo is private. The curl step silently fetches a 404 response and overwrites the CSS file, breaking all docs styling on public CI runners.

## Test plan
- [x] Built docs locally with `uv run zensical build`
- [x] Verified brand styling renders correctly via Playwright screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)