### PR TITLE
ci: skip grippy review on dependabot PRs

### DIFF
--- a/.github/workflows/grippy-review.yml
+++ b/.github/workflows/grippy-review.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   review:
     name: Grippy Code Review
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 


### PR DESCRIPTION
## Summary

- Skip the Grippy Code Review job when the PR actor is `dependabot[bot]`
- Dependabot runs in a restricted secret context without access to `OPENAI_API_KEY`, causing the LLM review to fail with parse errors on every retry (see PR #43)
- Other CI checks (tests, lint, CodeQL, Semgrep) still run normally on Dependabot PRs

## Test plan

- [ ] Verify this PR's CI passes (Grippy should still run since actor is not dependabot)
- [ ] Re-run or trigger a new Dependabot PR to confirm the job is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)